### PR TITLE
fix: highlight properties as `@property`

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -78,6 +78,6 @@
 (environ_value "env" @function.builtin (identifier) @variable)
 
 (id_selector "#" @punctuation.special)
-(property_name) @variable
+(property_name) @property
 
 (ERROR) @error


### PR DESCRIPTION
I think this just makes sense, let alone for consistency with css